### PR TITLE
Add NAV_DECLARE_ENUM_CLASS and NAV_DECLARE_ENUM_STRUCT  macros

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ## Checklist
 
-- [x] Implement `NAV_DECLARE_ENUM` without recursive macro instantiation
+- [x] Implement `NAV_DECLARE_ENUM`, `NAV_DECLARE_ENUM_CLASS` and `NAV_DECLARE_ENUM_STRUCT` without recursive macro instantiation
 - [x] Remove limit on number of elements in an enumeration
 - [x] Support enumerations with non-trivial dependencies (these are enumerations
       whose values depend on other members of the enumeration)
@@ -76,7 +76,7 @@ preceeding members. For example, Green is defined in terms of Yellow and Red
 
 ```cpp
 
-nav_declare_enum(
+nav_declare_enum_class(
     RainbowColors,
     int,
     Red = 0xff0000,

--- a/include/nav/nav_core.hpp
+++ b/include/nav/nav_core.hpp
@@ -498,8 +498,7 @@ template <class Enum>
 constexpr enum_name_list<Enum> enum_names {};
 } // namespace nav
 
-#define NAV_DECLARE_ENUM(EnumType, BaseType, ...)                              \
-    enum class EnumType : BaseType { __VA_ARGS__ };                            \
+#define NAV_DECLARE_COMMON_ENUM(EnumType, BaseType, ...)                       \
     namespace nav::detail {                                                    \
     template <>                                                                \
     struct enum_type_info_base<EnumType> {                                     \
@@ -548,8 +547,26 @@ constexpr enum_name_list<Enum> enum_names {};
     };                                                                         \
     } // namespace nav::detail
 
+#define NAV_DECLARE_ENUM(EnumType, BaseType, ...)                              \
+    enum EnumType : BaseType { __VA_ARGS__ };                                  \
+    NAV_DECLARE_COMMON_ENUM(EnumType, BaseType, __VA_ARGS__)
+
+#define NAV_DECLARE_ENUM_CLASS(EnumType, BaseType, ...)                        \
+    enum class EnumType : BaseType { __VA_ARGS__ };                            \
+    NAV_DECLARE_COMMON_ENUM(EnumType, BaseType, __VA_ARGS__)
+
+#define NAV_DECLARE_ENUM_STRUCT(EnumType, BaseType, ...)                       \
+    enum struct EnumType : BaseType { __VA_ARGS__ };                           \
+    NAV_DECLARE_COMMON_ENUM(EnumType, BaseType, __VA_ARGS__)
+
 #ifndef NAV_NO_PRETTY_MACROS
 #define nav_declare_enum(EnumType, BaseType, ...)                              \
     NAV_DECLARE_ENUM(EnumType, BaseType, __VA_ARGS__)
+
+#define nav_declare_enum_class(EnumType, BaseType, ...)                        \
+    NAV_DECLARE_ENUM_CLASS(EnumType, BaseType, __VA_ARGS__)
+
+#define nav_declare_enum_struct(EnumType, BaseType, ...)                       \
+    NAV_DECLARE_ENUM_STRUCT(EnumType, BaseType, __VA_ARGS__)
 #endif
 #endif

--- a/include/nav/nav_core.hpp
+++ b/include/nav/nav_core.hpp
@@ -417,7 +417,7 @@ struct enum_type_info_base {
 // Base type for enum_values
 template <class Enum>
 struct enum_value_list_base : enum_type_info_base<Enum> {
-    Enum values[0] {};
+    Enum __nav_internal_values__[0] {};
 };
 // Base type for enum_names
 template <class Enum>
@@ -452,13 +452,13 @@ struct enum_value_list : enum_type_info<Enum> {
     using iterator = Enum const*;
     using const_iterator = Enum const*;
     constexpr Enum const* begin() const noexcept {
-        return values.values;
+        return values.__nav_internal_values__;
     }
     constexpr Enum const* end() const noexcept {
-        return values.values + super::num_states;
+        return values.__nav_internal_values__ + super::num_states;
     }
     constexpr Enum const& operator[](size_t i) const noexcept {
-        return values.values[i];
+        return values.__nav_internal_values__[i];
     }
 };
 template <class Enum>
@@ -498,75 +498,75 @@ template <class Enum>
 constexpr enum_name_list<Enum> enum_names {};
 } // namespace nav
 
-#define NAV_DECLARE_COMMON_ENUM(EnumType, BaseType, ...)                       \
-    namespace nav::detail {                                                    \
-    template <>                                                                \
-    struct enum_type_info_base<EnumType> {                                     \
-        using base_type = BaseType;                                            \
-        constexpr static std::string_view qualified_type_name = #EnumType;     \
-        constexpr static std::string_view type_name = get_top_name(#EnumType); \
-        constexpr static bool is_nav_enum = true;                              \
-        constexpr static size_t num_states = []() -> size_t {                  \
-            enum_maker<BaseType> __VA_ARGS__;                                  \
-            enum_maker<BaseType> NAV_DECLARE_ENUM_vals[] {__VA_ARGS__};        \
-            return sizeof(NAV_DECLARE_ENUM_vals)                               \
-                 / sizeof(enum_maker<BaseType>);                               \
-        }();                                                                   \
-        constexpr static size_t size() noexcept {                              \
-            return num_states;                                                 \
-        }                                                                      \
-    };                                                                         \
-    template <>                                                                \
-    struct enum_value_list_base<EnumType> : enum_type_info_base<EnumType> {    \
-        EnumType values[enum_type_info_base<EnumType>::num_states];            \
-        constexpr enum_value_list_base()                                       \
-          : values() {                                                         \
-            enum_maker<BaseType> __VA_ARGS__;                                  \
-            value_assigner<BaseType> {}, __VA_ARGS__;                          \
-            enum_maker<BaseType> NAV_DECLARE_ENUM_vals[] {__VA_ARGS__};        \
-            for (size_t i = 0; i < enum_type_info_base<EnumType>::num_states;  \
-                 i++)                                                          \
-                this->values[i] = EnumType(NAV_DECLARE_ENUM_vals[i]);          \
-        }                                                                      \
-    };                                                                         \
-    template <>                                                                \
-    struct enum_name_list_base<EnumType> : enum_type_info_base<EnumType> {     \
-        using enum_type_info_base<EnumType>::num_states;                       \
-        constexpr static size_t                                                \
-            name_block_size = compute_name_block_size<num_states>(             \
-                #__VA_ARGS__);                                                 \
-        using block_type = string_block<num_states, name_block_size>;          \
-        block_type name_block;                                                 \
-        constexpr enum_name_list_base()                                        \
-          : name_block([](auto& block) {                                       \
-              write_names_and_sizes<num_states>(                               \
-                  #__VA_ARGS__,                                                \
-                  block.data,                                                  \
-                  block.offsets);                                              \
-          }) {}                                                                \
-    };                                                                         \
+#define NAV_DECLARE_COMMON_ENUM(EnumType, BaseType, ...)                               \
+    namespace nav::detail {                                                            \
+    template <>                                                                        \
+    struct enum_type_info_base<EnumType> {                                             \
+        using base_type = BaseType;                                                    \
+        constexpr static std::string_view qualified_type_name = #EnumType;             \
+        constexpr static std::string_view type_name = get_top_name(#EnumType);         \
+        constexpr static bool is_nav_enum = true;                                      \
+        constexpr static size_t num_states = []() -> size_t {                          \
+            enum_maker<BaseType> __VA_ARGS__;                                          \
+            enum_maker<BaseType> NAV_DECLARE_ENUM_vals[] {__VA_ARGS__};                \
+            return sizeof(NAV_DECLARE_ENUM_vals)                                       \
+                 / sizeof(enum_maker<BaseType>);                                       \
+        }();                                                                           \
+        constexpr static size_t size() noexcept {                                      \
+            return num_states;                                                         \
+        }                                                                              \
+    };                                                                                 \
+    template <>                                                                        \
+    struct enum_value_list_base<EnumType> : enum_type_info_base<EnumType> {            \
+        EnumType __nav_internal_values__[enum_type_info_base<EnumType>::num_states];   \
+        constexpr enum_value_list_base()                                               \
+          : __nav_internal_values__() {                                                \
+            enum_maker<BaseType> __VA_ARGS__;                                          \
+            value_assigner<BaseType> {}, __VA_ARGS__;                                  \
+            enum_maker<BaseType> NAV_DECLARE_ENUM_vals[] {__VA_ARGS__};                \
+            for (size_t i = 0; i < enum_type_info_base<EnumType>::num_states;          \
+                 i++)                                                                  \
+                this->__nav_internal_values__[i] = EnumType(NAV_DECLARE_ENUM_vals[i]); \
+        }                                                                              \
+    };                                                                                 \
+    template <>                                                                        \
+    struct enum_name_list_base<EnumType> : enum_type_info_base<EnumType> {             \
+        using enum_type_info_base<EnumType>::num_states;                               \
+        constexpr static size_t                                                        \
+            name_block_size = compute_name_block_size<num_states>(                     \
+                #__VA_ARGS__);                                                         \
+        using block_type = string_block<num_states, name_block_size>;                  \
+        block_type name_block;                                                         \
+        constexpr enum_name_list_base()                                                \
+          : name_block([](auto& block) {                                               \
+              write_names_and_sizes<num_states>(                                       \
+                  #__VA_ARGS__,                                                        \
+                  block.data,                                                          \
+                  block.offsets);                                                      \
+          }) {}                                                                        \
+    };                                                                                 \
     } // namespace nav::detail
 
-#define NAV_DECLARE_ENUM(EnumType, BaseType, ...)                              \
-    enum EnumType : BaseType { __VA_ARGS__ };                                  \
+#define NAV_DECLARE_ENUM(EnumType, BaseType, ...)                                      \
+    enum EnumType : BaseType { __VA_ARGS__ };                                          \
     NAV_DECLARE_COMMON_ENUM(EnumType, BaseType, __VA_ARGS__)
 
-#define NAV_DECLARE_ENUM_CLASS(EnumType, BaseType, ...)                        \
-    enum class EnumType : BaseType { __VA_ARGS__ };                            \
+#define NAV_DECLARE_ENUM_CLASS(EnumType, BaseType, ...)                                \
+    enum class EnumType : BaseType { __VA_ARGS__ };                                    \
     NAV_DECLARE_COMMON_ENUM(EnumType, BaseType, __VA_ARGS__)
 
-#define NAV_DECLARE_ENUM_STRUCT(EnumType, BaseType, ...)                       \
-    enum struct EnumType : BaseType { __VA_ARGS__ };                           \
-    NAV_DECLARE_COMMON_ENUM(EnumType, BaseType, __VA_ARGS__)
+#define NAV_DECLARE_ENUM_STRUCT(EnumType, BaseType, ...)                               \
+  enum struct EnumType : BaseType { __VA_ARGS__ };                                     \
+  NAV_DECLARE_COMMON_ENUM(EnumType, BaseType, __VA_ARGS__)
 
 #ifndef NAV_NO_PRETTY_MACROS
-#define nav_declare_enum(EnumType, BaseType, ...)                              \
+#define nav_declare_enum(EnumType, BaseType, ...)                                      \
     NAV_DECLARE_ENUM(EnumType, BaseType, __VA_ARGS__)
 
-#define nav_declare_enum_class(EnumType, BaseType, ...)                        \
+#define nav_declare_enum_class(EnumType, BaseType, ...)                                \
     NAV_DECLARE_ENUM_CLASS(EnumType, BaseType, __VA_ARGS__)
 
-#define nav_declare_enum_struct(EnumType, BaseType, ...)                       \
-    NAV_DECLARE_ENUM_STRUCT(EnumType, BaseType, __VA_ARGS__)
+#define nav_declare_enum_struct(EnumType, BaseType, ...)                               \
+  NAV_DECLARE_ENUM_STRUCT(EnumType, BaseType, __VA_ARGS__)
 #endif
 #endif

--- a/include/nav/nav_core.hpp
+++ b/include/nav/nav_core.hpp
@@ -498,11 +498,10 @@ template <class Enum>
 constexpr enum_name_list<Enum> enum_names {};
 } // namespace nav
 
-          }) {}                                                                        \
 #define __NAV_CONCAT___(str1, str2) (str1 "::" str2)
 #define __NAV_CONCAT__(str1, str2) (#str1 "::" #str2)
 
-#define NAV_DECLARE_COMMON_ENUM(NamespaceName, EEnumType, BaseType, ...)                                     \
+#define NAV_DECLARE_COMMON_ENUM(NamespaceName, EnumType, BaseType, ...)                                     \
     namespace nav::detail {                                                                                  \
     template <>                                                                                              \
     struct enum_type_info_base<EnumType> {                                                                   \

--- a/test_code/count_states_x10.cpp
+++ b/test_code/count_states_x10.cpp
@@ -4,16 +4,16 @@
 #define NUM_VALUES 1
 #define TEST_VALUES E0
 #endif
-nav_declare_enum(Test0, int, TEST_VALUES);
-nav_declare_enum(Test1, int, TEST_VALUES);
-nav_declare_enum(Test2, int, TEST_VALUES);
-nav_declare_enum(Test3, int, TEST_VALUES);
-nav_declare_enum(Test4, int, TEST_VALUES);
-nav_declare_enum(Test5, int, TEST_VALUES);
-nav_declare_enum(Test6, int, TEST_VALUES);
-nav_declare_enum(Test7, int, TEST_VALUES);
-nav_declare_enum(Test8, int, TEST_VALUES);
-nav_declare_enum(Test9, int, TEST_VALUES);
+nav_declare_enum_class(Test0, int, TEST_VALUES);
+nav_declare_enum_class(Test1, int, TEST_VALUES);
+nav_declare_enum_class(Test2, int, TEST_VALUES);
+nav_declare_enum_class(Test3, int, TEST_VALUES);
+nav_declare_enum_class(Test4, int, TEST_VALUES);
+nav_declare_enum_class(Test5, int, TEST_VALUES);
+nav_declare_enum_class(Test6, int, TEST_VALUES);
+nav_declare_enum_class(Test7, int, TEST_VALUES);
+nav_declare_enum_class(Test8, int, TEST_VALUES);
+nav_declare_enum_class(Test9, int, TEST_VALUES);
 
 
 static_assert(NUM_VALUES == nav::num_states<Test0>);

--- a/test_code/print_names.cpp
+++ b/test_code/print_names.cpp
@@ -5,7 +5,7 @@
 #define NUM_VALUES 1
 #define TEST_VALUES E0
 #endif
-nav_declare_enum(TestEnum, int, TEST_VALUES);
+nav_declare_enum_class(TestEnum, int, TEST_VALUES);
 
 int main() {
     for (std::string_view name : nav::enum_names<TestEnum>) {

--- a/tests/fuzzy_match.cpp
+++ b/tests/fuzzy_match.cpp
@@ -6,7 +6,7 @@
 #include <string>
 
 // clang-format off
-nav_declare_enum(
+nav_declare_enum_class(
     CommonWords, // Name of enum
     int,         // Base type
     // A h*ck-ton of words varying in length from 5-7 leters

--- a/tests/nav_core.cpp
+++ b/tests/nav_core.cpp
@@ -3,7 +3,7 @@
 #include <nav/nav_core.hpp>
 #include <type_traits>
 
-nav_declare_enum(
+nav_declare_enum_class(
     RainbowColors,
     int,
     Red = 0xff0000,

--- a/tests/nav_extra.cpp
+++ b/tests/nav_extra.cpp
@@ -6,7 +6,7 @@ namespace test_nav {
 enum class Color;
 }
 
-nav_declare_enum(test_nav::Color, int, Red, Green, Blue);
+nav_declare_enum_class(test_nav::Color, int, Red, Green, Blue);
 
 TEST_CASE("Testing nav_libfmt", "[extra][fmt]") {
     using test_nav::Color;

--- a/tests/nav_iostream.cpp
+++ b/tests/nav_iostream.cpp
@@ -14,7 +14,7 @@ namespace test_nav {
 enum class Color;
 }
 
-nav_declare_enum(test_nav::Color, int, Red, Green, Blue);
+nav_declare_enum_class(test_nav::Color, int, Red, Green, Blue);
 
 TEST_CASE("Testing nav_iostream", "[extra][stream]") {
     using test_nav::Color;

--- a/tests/nav_lowercase.cpp
+++ b/tests/nav_lowercase.cpp
@@ -2,7 +2,7 @@
 #include <nav/nav_lowercase.hpp>
 #include <fmt/core.h>
 
-nav_declare_enum(
+nav_declare_enum_class(
     RainbowColors,
     int,
     Red = 0xff0000,

--- a/tests/sparse_enums.cpp
+++ b/tests/sparse_enums.cpp
@@ -12,7 +12,7 @@ enum class AnotherEnum {
     Value3,
 };
 
-nav_declare_enum(
+nav_declare_enum_class(
     FooBar::FibonacciNumbers, // Name
     int64_t,                  // Base type
     F0 = 0,


### PR DESCRIPTION
Hello,

I have updated nav to support the different enumeration declarations:
* enum
* enum class
* enum struct

see [cppreference](https://en.cppreference.com/w/cpp/language/enum) for more information

Here are the new macros created:
* NAV_DECLARE_COMMON_ENUM : common macro to the other macros (it's the one that really does the work).
* NAV_DECLARE_ENUM : nav declaration for the `enum` type
* NAV_DECLARE_ENUM_CLASS : nav declaration for the `enum class` type
* NAV_DECLARE_ENUM_STRUCT : nav declaration for type `struct`
* nav_declare_enum : nav pretty declaration for type `enum`
* nav_declare_enum_class : nav pretty declaration for type `enum class`
* nav_declare_enum_struct : nav pretty declaration for type `enum struct`

As the previous macro `NAV_DECLARE_ENUM` is now used for `enum`, I updated the tests and the documentation with `NAV_DECLARE_ENUM_CLASS`macro.

Regards,
Gammasoft
